### PR TITLE
Support DIA PASEF file conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pythonenv3.8
 **.zip
 **.d
 test/
+**.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pythonenv3.8
 **.d
 test/
 **.DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## Python script to convert Bruker TDF format to MzML
 
 ### Tested with TimsTof Pro TDF 2.0 using SDK version 2.8.7
+#### support added for DIA data. DIA MS/MS only supports centroid output
 
 ### SDK Requirement
 The preffered method to run this application is via docker. Bruker has allowed us to include the lib and python api (SDK version 2.8.7) in this repo for the purpose of building the docker image. To run the python script outside of docker you will need to obtain the SDK directly from Bruker.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cycler==0.10.0
 kiwisolver==1.2.0
-lxml==4.6.2
+lxml==4.6.3
 matplotlib==3.2.1
 numpy==1.18.3
 pandas==1.0.3

--- a/tdf2mzml.py
+++ b/tdf2mzml.py
@@ -884,7 +884,6 @@ def write_pasef_dia_spectrum(mzml_data_struct):
 
     precursor_info["isolation_window_args"] = dict()
 
-    precursor_info["mz"] = mz_center
     precursor_info["isolation_window_args"]["target"] = mz_center
 
     isolation_width = mz_width/2.0
@@ -899,12 +898,13 @@ def write_pasef_dia_spectrum(mzml_data_struct):
         id=msn_spectrum_id,
         centroided=True,
         scan_start_time=mzml_data_struct['current_dia_frame']['frame'][1]/60,
-        scan_window_list=[(
-            mz_center-mz_width/2.0,
-            mz_center+mz_width/2.0,
-        )],
+        # TODO: report proper scan window (the range of fragment masses scanned in this scan)
+        # scan_window_list=[(
+        #     mz_center-mz_width/2.0,
+        #     mz_center+mz_width/2.0,
+        # )],
         compression=mzml_data_struct['compression'],
-        #precursor_information=precursor_info,
+        precursor_information=precursor_info,
         params=[
             {"ms level": 2},
             {"total ion current": ms2_i_array.sum()}

--- a/tdf2mzml.py
+++ b/tdf2mzml.py
@@ -898,11 +898,10 @@ def write_pasef_dia_spectrum(mzml_data_struct):
         id=msn_spectrum_id,
         centroided=True,
         scan_start_time=mzml_data_struct['current_dia_frame']['frame'][1]/60,
-        # TODO: report proper scan window (the range of fragment masses scanned in this scan)
-        # scan_window_list=[(
-        #     mz_center-mz_width/2.0,
-        #     mz_center+mz_width/2.0,
-        # )],
+        scan_window_list=[(
+            mzml_data_struct['data_dict']['mz_acq_range_lower'],
+            mzml_data_struct['data_dict']['mz_acq_range_upper']
+        )],
         compression=mzml_data_struct['compression'],
         precursor_information=precursor_info,
         params=[

--- a/tdf2mzml.py
+++ b/tdf2mzml.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 
+#
 # # Project: OpenMS Compatible MzML generators
 # Developer: Michael A. Freitas
 #
@@ -9,10 +9,10 @@
 # # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. 
+# LICENSE file in the root directory of this source tree.
 
-import argparse 
-import collections 
+import argparse
+import collections
 import hashlib
 import logging
 import math
@@ -25,18 +25,18 @@ import sys
 import time
 import timsdata as timsdata
 
-NAME = 'tdf2mzml' 
+NAME = 'tdf2mzml'
 MAJOR_VERSION = '0.3'
 MINOR_VERSION = '20200211.1'
 DEBUG = True
 
 # precursor column information
 precursor_columns = [
-            "Id", 
-            "LargestPeakMz", 
-            "AverageMz", 
-            "MonoisotopicMz", 
-            "ScanNumber", 
+            "Id",
+            "LargestPeakMz",
+            "AverageMz",
+            "MonoisotopicMz",
+            "ScanNumber",
             "Charge",
             "Intensity",
             "Parent"
@@ -62,7 +62,7 @@ def timing(f):
         time2 = time.time()
         logging.info('{:s} function took {:.3f} s'.format(f.__name__, (time2-time1)))
         return ret
-    
+
     return wrap
 
 
@@ -82,7 +82,7 @@ def scan_progress(mzml_data_struct,interval=1000):
     Returns
     -------
     None
-    """ 
+    """
     if mzml_data_struct['scan_index'] % int(interval) == 0:
         end_time = time.time()
         logging.info("Processed {} of {} scans in {:.3f} s".format(
@@ -90,10 +90,10 @@ def scan_progress(mzml_data_struct,interval=1000):
             mzml_data_struct['data_dict']['total_spectra'],
             end_time - mzml_data_struct['scan_loop_time1']
             ))
-            
+
         mzml_data_struct['scan_loop_time1'] = end_time
 
-    return 
+    return
 
 
 @timing
@@ -109,7 +109,7 @@ def sha1_checksum(path_name):
     Returns
     -------
     sha1 hash
-    """ 
+    """
     BLOCKSIZE = 65536
     hasher = hashlib.sha1()
     with open(path_name, 'rb') as afile:
@@ -137,11 +137,12 @@ def centroid_precursor_frame(mzml_data_struct):
     -------
     list of lists
         list of mz and i lists [[mz,[i]]
-    """ 
-    precursor_frame_id = mzml_data_struct['current_precursor']['id'] 
+    """
+    precursor_frame_id = mzml_data_struct['current_precursor']['id']
     num_scans = mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={0}".format(precursor_frame_id)).fetchone()[0]
+    print(mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={}".format(precursor_frame_id)).fetchone())
     data_list = mzml_data_struct['td'].extractCentroidedSpectrumForFrame (precursor_frame_id, 0, num_scans)
-    
+    print(np.array(data_list))
     return np.array(data_list)
 
 
@@ -161,12 +162,19 @@ def profile_precursor_frame(mzml_data_struct):
     -------
     list of lists
         list of mz and i lists [[mz,[i]]
-    """ 
-    precursor_frame_id = mzml_data_struct['current_precursor']['id'] 
-    num_scans = mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={0}".format(precursor_frame_id)).fetchone()[0]
-    i_array = mzml_data_struct['td'].extractProfileForFrame(precursor_frame_id, 0, num_scans)
-    m_array = mzml_data_struct['td'].indexToMz(precursor_frame_id,list(range(0, num_scans) ))
+    """
+    precursor_frame_id = mzml_data_struct['current_precursor']['id']
+    num_scans = mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={}".format(precursor_frame_id)).fetchone()[0]
     
+    #SDK takes 0-num_scans as input.
+    i_array = mzml_data_struct['td'].extractProfileForFrame(precursor_frame_id, 0, num_scans)
+
+    # ******
+    #TODO Get size of i_array and then set range from 0,sizeof(i_array)-1
+    #Implemented fix needs testing
+    m_array = mzml_data_struct['td'].indexToMz(precursor_frame_id,
+                                               list(range(0, len(i_array))))
+
     return np.array([m_array, i_array])
 
 
@@ -186,8 +194,8 @@ def raw_precursor_frame(mzml_data_struct):
     -------
     list of lists
         list of mz and i lists [[mz,[i]]
-    """ 
-    precursor_frame_id = mzml_data_struct['current_precursor']['id'] 
+    """
+    precursor_frame_id = mzml_data_struct['current_precursor']['id']
     # build merged array of m/z and intensities
     num_scans = mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={0}".format(precursor_frame_id)).fetchone()[0]
     raw_position_dict = collections.defaultdict(int)
@@ -204,7 +212,7 @@ def raw_precursor_frame(mzml_data_struct):
 
             if i >= mzml_data_struct['ms1_threshold']:
                 raw_position_dict[mz] += i
-    
+
     return list( zip(*raw_position_dict.items()) )
 
 
@@ -223,7 +231,7 @@ def get_spectrum_dict(mzml_data_struct):
     -------
     dict: 
         spectrum dictionary
-    """ 
+    """
     spectrum_dict = collections.OrderedDict()
 
     pasef_frame_columns = ['Frame','IsolationMz','CollisionEnergy', 'IsolationWidth']
@@ -233,7 +241,7 @@ def get_spectrum_dict(mzml_data_struct):
     spectrum_dict['acq_softare'] = mzml_data_struct['td'].conn.execute(
             "Select Value from GlobalMetadata where key=\"AcquisitionSoftware\""
         ).fetchone()[0]
-    
+
     spectrum_dict['acq_softare_version'] = mzml_data_struct['td'].conn.execute(
             "Select Value from GlobalMetadata where key=\"AcquisitionSoftwareVersion\""
         ).fetchone()[0]
@@ -264,16 +272,16 @@ def get_spectrum_dict(mzml_data_struct):
     logging.debug("number of type 0 frames: {}".format(MMsMsType0_frames))
 
     MMsMsType0_spectra = MMsMsType0_frames
-    
+
     #Get MS1 MMsMsType0 Frames from TDF
     MMsMsType8_frames = len(mzml_data_struct['td'].conn.execute("SELECT Id , Time From Frames where MsMsType=8").fetchall())
     logging.debug("number of type 8 frames: {}".format(MMsMsType8_frames))
-    
+
     if MMsMsType8_frames > 0:
         MMsMsType8_spectra = mzml_data_struct['td'].conn.execute("SELECT COUNT(*) FROM Precursors").fetchone()[0]
         logging.debug("number of type 8 spectra: {}".format(MMsMsType8_spectra))
-        
-        spectrum_dict['PASEFMSMS_type8'] = 1            
+
+        spectrum_dict['PASEFMSMS_type8'] = 1
         # for MMsMsType0_frame in MMsMsType0_frames:
 
         #     precursor_frame_id = MMsMsType0_frame[0]
@@ -287,74 +295,74 @@ def get_spectrum_dict(mzml_data_struct):
         #logging.debug("number spectra: {}".format(total_spectrum_count))
     else:
         MMsMsType8_spectra = 0
-        spectrum_dict['PASEFMSMS_type8'] = 0      
-    
-        
+        spectrum_dict['PASEFMSMS_type8'] = 0
+
+
     #Get MS9 MMsMsType9 Frames from TDF
     MMsMsType9_frames = len(mzml_data_struct['td'].conn.execute("SELECT Id , Time From Frames where MsMsType=9").fetchall())
     logging.debug("number of type 9 frames: {}".format(MMsMsType9_frames))
-    
+
     if MMsMsType9_frames > 0:
         MMsMsType9_spectra = MMsMsType9_frames
-        spectrum_dict['PASEFMSMS_type9'] = 1  
+        spectrum_dict['PASEFMSMS_type9'] = 1
     else:
         MMsMsType9_spectra = 0
-        spectrum_dict['PASEFMSMS_type9'] = 0      
-           
+        spectrum_dict['PASEFMSMS_type9'] = 0
+
     #spectrum_dict['total_spectra'] = total_spectrum_count
     spectrum_dict['total_spectra'] = MMsMsType0_spectra + MMsMsType8_spectra + MMsMsType9_frames
     spectrum_dict['ms1_spectra_count'] = MMsMsType0_spectra
-    spectrum_dict['ms2_spectra_count'] = MMsMsType8_spectra 
+    spectrum_dict['ms2_spectra_count'] = MMsMsType8_spectra
     spectrum_dict['dia_spectra_count'] = MMsMsType9_spectra
-    
+
     return spectrum_dict
 
 
-def get_num_spectra(mzml_data_struct):
-    """
-    Get the number of spectra for the conversion
+# def get_num_spectra(mzml_data_struct):
+#     """
+#     Get the number of spectra for the conversion
 
-    Helper function to determine number of spectra.  This function rescans the 
-    data file in order to account for the start and end frames.
+#     Helper function to determine number of spectra.  This function rescans the 
+#     data file in order to account for the start and end frames.
 
-    Parameters
-    ----------
-    mzml_data_struct : dict
-        structure of the mzml data
+#     Parameters
+#     ----------
+#     mzml_data_struct : dict
+#         structure of the mzml data
 
-    Returns
-    -------
-    int:
-        spectrum count
-    """ 
-    total_spectrum_count = 0
+#     Returns
+#     -------
+#     int:
+#         spectrum count
+#     """
+#     total_spectrum_count = 0
 
-    #Get Frames from TDF
-    frames = mzml_data_struct['td'].conn.execute("SELECT * From Frames where MsMsType=0").fetchall()
+#     #Get Frames from TDF
+#     frames = mzml_data_struct['td'].conn.execute("SELECT * From Frames where MsMsType=0").fetchall()
 
-    for frame in frames:
-        frame_id = frame[0]
+#     for frame in frames:
+#         frame_id = frame[0]
 
-        #Skip Frames outside the requested Frame range
-        #TODO add capability to request scan times in addition to frame range
-        if mzml_data_struct['start_frame'] != -1 and frame_id < mzml_data_struct['start_frame']:
-            continue
-        
-        if mzml_data_struct['end_frame'] != -1 and frame_id > mzml_data_struct['end_frame']:
-            break
+#         #Skip Frames outside the requested Frame range
+#         #TODO add capability to request scan times in addition to frame range
+#         if mzml_data_struct['start_frame'] != -1 and frame_id < mzml_data_struct['start_frame']:
+#             continue
 
-        total_spectrum_count +=1
+#         if mzml_data_struct['end_frame'] != -1 and frame_id > mzml_data_struct['end_frame']:
+#             break
 
-        #Get number of MS2 Spectra for each precuros in a give Frame
-        ms2_spectra = mzml_data_struct['td'].conn.execute(
-                            "Select * From Precursors where Parent={}"
-                            .format(frame_id)
-                            ).fetchall()
+#         total_spectrum_count +=1
 
-        if len(ms2_spectra) >= 1: 
-            total_spectrum_count += len(ms2_spectra)
+#         #Get number of MS2 Spectra for each precuros in a give Frame
+#         ms2_spectra = mzml_data_struct['td'].conn.execute(
+#                             "Select * From Precursors where Parent={}"
+#                             .format(frame_id)
+#                             ).fetchall()
 
-    return total_spectrum_count
+#         if len(ms2_spectra) >= 1:
+#             total_spectrum_count += len(ms2_spectra)
+
+#     return total_spectrum_count
 
 
 def write_sourcefile_list(mzml_data_struct):
@@ -371,7 +379,7 @@ def write_sourcefile_list(mzml_data_struct):
     Returns
     -------
     None
-    """   
+    """
     sf_list = list()
 
     # SourceFile 'analysis.tdf'
@@ -379,9 +387,9 @@ def write_sourcefile_list(mzml_data_struct):
     tdf_path = os.path.join(mzml_data_struct['input'],tdf_file_name)
     tdf_id = tdf_path.replace('/',"__")
     sf1 = mzml_data_struct['writer'].SourceFile(
-        tdf_path, 
-        tdf_file_name, 
-        id=tdf_id, 
+        tdf_path,
+        tdf_file_name,
+        id=tdf_id,
         params=[
             {"Bruker TDF nativeID format": ""},
             {"Bruker TDF format": ""},
@@ -393,10 +401,10 @@ def write_sourcefile_list(mzml_data_struct):
     # SourceFile 'analysis.tdf_bin'
     tdf_file_name = 'analysis.tdf_bin'
     tdf_path = os.path.join(mzml_data_struct['input'],tdf_file_name)
-    tdf_id = tdf_path.replace('/',"__")   
+    tdf_id = tdf_path.replace('/',"__")
     sf2 = mzml_data_struct['writer'].SourceFile(
-        tdf_path, 
-        tdf_file_name, 
+        tdf_path,
+        tdf_file_name,
         id=tdf_id,
         params=[
             {"Bruker TDF nativeID format": ""},
@@ -407,7 +415,7 @@ def write_sourcefile_list(mzml_data_struct):
     sf_list.append(sf2)
 
     mzml_data_struct['writer'].file_description( ["MS1 spectrum","MSn spectrum"] , sf_list )
-    return 
+    return
 
 def write_reference_param_group_list(mzml_data_struct):
     """
@@ -423,13 +431,13 @@ def write_reference_param_group_list(mzml_data_struct):
     Returns
     -------
     None
-    """  
+    """
     # TODO Figure out how to add reference to Run section as in PWiz
     rpgl_list = list()
 
-    rpgl_list.append( 
+    rpgl_list.append(
         mzml_data_struct['writer'].ReferenceableParamGroup(
-            id="CommonInstrumentParams", 
+            id="CommonInstrumentParams",
             params=[
                 {"Bruker Daltonics instrument model": ""},
             ]
@@ -437,7 +445,7 @@ def write_reference_param_group_list(mzml_data_struct):
     )
 
     mzml_data_struct['writer'].reference_param_group_list( rpgl_list )
-    return 
+    return
 
 def write_software_list(mzml_data_struct):
     """
@@ -453,7 +461,7 @@ def write_software_list(mzml_data_struct):
     Returns
     -------
     None
-    """  
+    """
     # TODO: build up the software list
     # TODO: Automate collecting Sofware names and versions
     software_list = list()
@@ -471,7 +479,7 @@ def write_software_list(mzml_data_struct):
             "Select Value from GlobalMetadata where key=\"MzAcqRangeUpper\""
         ).fetchone()[0]
 
-### SDK Description
+    ### SDK Description
     software_list.append( {
             "id": "TIMS_SDK",
             "version": "2.8.7",
@@ -481,7 +489,7 @@ def write_software_list(mzml_data_struct):
             ]
         } )
 
-### micrOTOFcontrol Description
+    ### micrOTOFcontrol Description
     software_list.append( {
         "id": acq_softare,
         "version": acq_softare_version,
@@ -490,7 +498,7 @@ def write_software_list(mzml_data_struct):
         ]
     } )
 
-### python Description
+    ### python Description
     software_list.append( {
         "id": NAME,
         "version": MAJOR_VERSION + "-" + MINOR_VERSION,
@@ -500,7 +508,7 @@ def write_software_list(mzml_data_struct):
     } )
 
     mzml_data_struct['writer'].software_list(software_list)
-    return 
+    return
 
 def write_instrument_configuration_list(mzml_data_struct):
     """
@@ -516,24 +524,24 @@ def write_instrument_configuration_list(mzml_data_struct):
     Returns
     -------
     None
-    """  
+    """
     # TODO FIX DESCRIPTION
     instrument_configurations = list()
     source = mzml_data_struct['writer'].Source(1, ["nanospray inlet", "quadrupole"])
     analyzer = mzml_data_struct['writer'].Analyzer(2, ["time-of-flight"])
     detector = mzml_data_struct['writer'].Detector(3, ["microchannel plate detector","photomultiplier"])
     serial_number = mzml_data_struct['data_dict']['instrument_serial_number']
-    
+
     instparams=[
         {"instrument serial number": serial_number}
     ]
-       
+
     if mzml_data_struct['data_dict']['PASEFMSMS_type9'] == 1:
 
-        windows = mzml_data_struct['td'].conn.execute("SELECT * From DiaFrameMsMsWindows").fetchall()                 
+        windows = mzml_data_struct['td'].conn.execute("SELECT * From DiaFrameMsMsWindows").fetchall()
         for window in windows:
 
-            instparams.append( 
+            instparams.append(
                 {"dia_window": {
                         'Group': window[0],
                         'mz_center': window[3],
@@ -543,15 +551,15 @@ def write_instrument_configuration_list(mzml_data_struct):
                     }
                 )
 
-                
-    
-                        
+
+
+
     instrument_configurations.append(
         mzml_data_struct['writer'].InstrumentConfiguration(
-            id="IC1", 
+            id="IC1",
             component_list=[
-                source, 
-                analyzer, 
+                source,
+                analyzer,
                 detector
             ],
             params=instparams
@@ -559,7 +567,7 @@ def write_instrument_configuration_list(mzml_data_struct):
     )
 
     mzml_data_struct['writer'].instrument_configuration_list(instrument_configurations)
-    return 
+    return
 
 def write_data_processing_list(mzml_data_struct):
     """
@@ -575,14 +583,14 @@ def write_data_processing_list(mzml_data_struct):
     Returns
     -------
     None
-    """  
+    """
     data_processing = list()
     methods = list()
 
     methods.append(
         mzml_data_struct['writer'].ProcessingMethod(
-            order=0, 
-            software_reference="tdf2mzml", 
+            order=0,
+            software_reference="tdf2mzml",
             params=[
                 "Conversion to mzML"
             ]
@@ -614,7 +622,7 @@ def write_header(mzml_data_struct):
     Returns
     -------
     None
-    """  
+    """
     mzml_data_struct['writer'].controlled_vocabularies()
     write_sourcefile_list(mzml_data_struct)
     write_reference_param_group_list(mzml_data_struct)
@@ -639,26 +647,27 @@ def write_precursor_frame(mzml_data_struct):
     Returns
     -------
     None
-    """  
-    precursor_frame_id = mzml_data_struct['current_precursor']['id'] 
+    """
+    precursor_frame_id = mzml_data_struct['current_precursor']['id']
     scan_start_time = mzml_data_struct['current_precursor']['start_time']
     # Process only frames in frame range
-    
+
     # build merged array of m/z and intensities
     if mzml_data_struct['ms1_type'] == 'raw':
         ms1_data = raw_precursor_frame(mzml_data_struct)
         centroided_flag = True
-    elif mzml_data_struct['ms1_type'] == 'profile': 
+    elif mzml_data_struct['ms1_type'] == 'profile':
         ms1_data = profile_precursor_frame(mzml_data_struct)
-    elif mzml_data_struct['ms1_type'] == 'centroid':                    
+        centroided_flag = False
+    elif mzml_data_struct['ms1_type'] == 'centroid':
         ms1_data = centroid_precursor_frame(mzml_data_struct)
         centroided_flag = True
-    
+
     ms1_mz_array = np.asarray(ms1_data[0])
     ms1_i_array = np.asarray(ms1_data[1])
 
     # Write MS1 Spectrum
-    
+
     mzml_data_struct['current_precursor']['spectrum_id'] = "index={}".format(mzml_data_struct['scan_index'])
 
     if len(ms1_mz_array) > 1:
@@ -672,17 +681,17 @@ def write_precursor_frame(mzml_data_struct):
         #TODO fix handling for sparce MS1/MS2 data the following is a crude fixe
         base_peak_intensity = total_ion_intensity = 0.0
         base_peak_mz = 0.0
-        
+
     mzml_data_struct['writer'].write_spectrum(
-        ms1_mz_array, 
-        ms1_i_array, 
-        id=mzml_data_struct['current_precursor']['spectrum_id'], 
+        ms1_mz_array,
+        ms1_i_array,
+        id=mzml_data_struct['current_precursor']['spectrum_id'],
         centroided=centroided_flag,
-        scan_start_time=scan_start_time, 
+        scan_start_time=scan_start_time,
         scan_window_list=[( mzml_data_struct['data_dict']['mz_acq_range_lower'] , mzml_data_struct['data_dict']['mz_acq_range_upper'] )],
         compression=mzml_data_struct['compression'],
         params=[
-                {"ms level": 1}, 
+                {"ms level": 1},
                 {"total ion current": total_ion_intensity},
                 {"base peak intensity": base_peak_intensity, 'unit_accession': 'MS:1000131'},
                 {"base peak m/z": base_peak_mz, 'unit_name': 'm/z'}
@@ -711,11 +720,11 @@ def get_precursor_list(mzml_data_struct):
         list of precursor values
     """
     # get MS2 spetrum for each precursor
-    precursor_frame_id = mzml_data_struct['current_precursor']['id'] 
+    precursor_frame_id = mzml_data_struct['current_precursor']['id']
 
     precursor_list = mzml_data_struct['td'].conn.execute(
         "Select {} From Precursors where Parent={}".format(
-            ",".join(precursor_columns), 
+            ",".join(precursor_columns),
             precursor_frame_id)
         ).fetchall()
 
@@ -735,7 +744,7 @@ def write_pasef_msms_spectrum(mzml_data_struct):
     Returns
     -------
     None
-    """                      
+    """
     precursor = {precursor_columns[i]: mzml_data_struct['current_precursor']['data'][i] for i in range(len(precursor_columns))}
 
     # Get MS2 Arrays
@@ -746,7 +755,7 @@ def write_pasef_msms_spectrum(mzml_data_struct):
     # Set Precuror metadata
     # TODO add additional metada
     # TODO clarify correct m/z for precursor to use for Isolation Width
-        
+
     msn_spectrum_id = "index={}".format(mzml_data_struct['scan_index'])
 
     parent_frame_list = mzml_data_struct['td'].conn.execute("SELECT Frame From PasefFrameMsMsInfo where Precursor={}".format(precursor['Id'])).fetchall()
@@ -755,30 +764,30 @@ def write_pasef_msms_spectrum(mzml_data_struct):
     pasef_frame_columns = ['IsolationMz','CollisionEnergy', 'IsolationWidth']
     pasef_frame_info_list = mzml_data_struct['td'].conn.execute(
         "SELECT {} From PasefFrameMsMsInfo where Precursor={}".format(
-            ",".join(pasef_frame_columns), 
+            ",".join(pasef_frame_columns),
             precursor['Id']
             )
         ).fetchone()
 
-    pasef_frame = {pasef_frame_columns[i]: pasef_frame_info_list[i] for i in range(len(pasef_frame_columns))} 
+    pasef_frame = {pasef_frame_columns[i]: pasef_frame_info_list[i] for i in range(len(pasef_frame_columns))}
 
     precursor_info = dict()
-    
+
     ion_mobilitiy = mzml_data_struct['td'].scanNumToOneOverK0 (precursor['Parent'], [ precursor['ScanNumber'] ]) [0]
     precursor_info['params'] = [
                 {"inverse reduced ion mobility": ion_mobilitiy, 'unit_accession': 'MS:1002814'}
             ]
-            
+
     precursor_info["spectrum_reference"] = mzml_data_struct['current_precursor']['spectrum_id']
 
     # TODO find the correct metadata and apply it here properly
     precursor_info["activation"] = [
-            "CID", 
+            "CID",
             {"collision energy": pasef_frame["CollisionEnergy"]}
             ]
 
     precursor_info["isolation_window_args"] = dict()
-    
+
     if precursor['Charge'] != None:
         precursor_mz = precursor['MonoisotopicMz']
         precursor_info["mz"] = precursor_mz
@@ -805,19 +814,19 @@ def write_pasef_msms_spectrum(mzml_data_struct):
         precursor_info["charge"]  = 2
 
     mzml_data_struct['writer'].write_spectrum(
-        ms2_mz_array, 
-        ms2_i_array, 
-        id=msn_spectrum_id, 
+        ms2_mz_array,
+        ms2_i_array,
+        id=msn_spectrum_id,
         centroided=True,
-        scan_start_time=mzml_data_struct['current_precursor']['start_time'], 
-        scan_window_list=[( 
+        scan_start_time=mzml_data_struct['current_precursor']['start_time'],
+        scan_window_list=[(
             mzml_data_struct['data_dict']['mz_acq_range_lower'],
-            mzml_data_struct['data_dict']['mz_acq_range_upper'] 
+            mzml_data_struct['data_dict']['mz_acq_range_upper']
         )],
         compression=mzml_data_struct['compression'],
         precursor_information=precursor_info,
         params=[
-            {"ms level": 2}, 
+            {"ms level": 2},
             {"total ion current": ms2_i_array.sum()}
         ]
     )
@@ -841,10 +850,10 @@ def write_pasef_dia_spectrum(mzml_data_struct):
     Returns
     -------
     None
-    """       
-    logging.debug("precursor \n{}".format(mzml_data_struct['current_precursor']))     
-    logging.debug("dia\n{}".format(mzml_data_struct['current_dia_frame']) )   
-    
+    """
+    logging.debug("precursor \n{}".format(mzml_data_struct['current_precursor']))
+    logging.debug("dia\n{}".format(mzml_data_struct['current_dia_frame']) )
+
     frame_id = mzml_data_struct['current_dia_frame']['id']
     start_scan = mzml_data_struct['current_dia_frame']['current_window'][1]
     end_scan = mzml_data_struct['current_dia_frame']['current_window'][2]
@@ -852,29 +861,29 @@ def write_pasef_dia_spectrum(mzml_data_struct):
     mz_width =  mzml_data_struct['current_dia_frame']['current_window'][4]
     collision_energy =  mzml_data_struct['current_dia_frame']['current_window'][5]
     #logging.debug(frame_id, start_scan, end_scan)
-    
+
     result = mzml_data_struct['td'].extractCentroidedSpectrumForFrame( frame_id, start_scan, end_scan)
 
     ms2_mz_array = np.asarray(result[0])
     ms2_i_array = np.asarray(result[1])
-    
+
     logging.debug("{}\n{}".format(ms2_mz_array,ms2_i_array))
     logging.debug(mzml_data_struct['scan_index'])
     msn_spectrum_id = "index={}".format(mzml_data_struct['scan_index'])
     logging.debug(mzml_data_struct['scan_index'])
 
     precursor_info = dict()
-    precursor_info["mz"] = mz_center        
+    precursor_info["mz"] = mz_center
     precursor_info["spectrum_reference"] = mzml_data_struct['current_precursor']['spectrum_id']
 
     # # TODO find the correct metadata and apply it here properly
     precursor_info["activation"] = [
-            "CID", 
+            "CID",
             {"collision energy": collision_energy}
             ]
 
     precursor_info["isolation_window_args"] = dict()
-    
+
     precursor_info["mz"] = mz_center
     precursor_info["isolation_window_args"]["target"] = mz_center
 
@@ -885,19 +894,19 @@ def write_pasef_dia_spectrum(mzml_data_struct):
 
 
     mzml_data_struct['writer'].write_spectrum(
-        ms2_mz_array, 
-        ms2_i_array, 
-        id=msn_spectrum_id, 
+        ms2_mz_array,
+        ms2_i_array,
+        id=msn_spectrum_id,
         centroided=True,
-        scan_start_time=mzml_data_struct['current_dia_frame']['frame'][1]/60, 
-        scan_window_list=[( 
+        scan_start_time=mzml_data_struct['current_dia_frame']['frame'][1]/60,
+        scan_window_list=[(
             mz_center-mz_width/2.0,
-            mz_center+mz_width/2.0, 
+            mz_center+mz_width/2.0,
         )],
         compression=mzml_data_struct['compression'],
         #precursor_information=precursor_info,
         params=[
-            {"ms level": 2}, 
+            {"ms level": 2},
             {"total ion current": ms2_i_array.sum()}
         ]
     )
@@ -926,7 +935,7 @@ def process_arg(args):
         dictionary of arguments
     """
     return vars(args)
-        
+
 @timing
 def write_mzml(args):
     """
@@ -943,7 +952,7 @@ def write_mzml(args):
     None
     """
     mzml_data_struct = process_arg(args)
-    
+
     ### Connect to TDF DB
     logging.info("transforming TDF to mzML file: {}".format(mzml_data_struct['input']))
 
@@ -953,9 +962,9 @@ def write_mzml(args):
     logging.info("{} Total Frames.".format(mzml_data_struct['data_dict']['frame_count']))
     logging.info("{} Total Spectra.".format(mzml_data_struct['data_dict']['total_spectra']))
     logging.info("{} MS1 Spectra.".format(mzml_data_struct['data_dict']['ms1_spectra_count']))
-    logging.info("{} MS2 DDA Scans.".format(mzml_data_struct['data_dict']['ms2_spectra_count']))    
-    logging.info("{} MS2 DIA Scans.".format(mzml_data_struct['data_dict']['dia_spectra_count']))    
-    
+    logging.info("{} MS2 DDA Scans.".format(mzml_data_struct['data_dict']['ms2_spectra_count']))
+    logging.info("{} MS2 DIA Scans.".format(mzml_data_struct['data_dict']['dia_spectra_count']))
+
     logging.info("writting to mzML file: {}".format(mzml_data_struct['output']))
     mzml_data_struct['writer'] = MzMLWriter(mzml_data_struct['output'])
     mzml_data_struct['writer'].begin()
@@ -966,7 +975,7 @@ def write_mzml(args):
     total_spectra_count = mzml_data_struct['data_dict']['total_spectra']
     logging.info("Processing {} Spectra.".format(total_spectra_count))
     logging.info("Reading, Merging and Formating Frames for mzML")
-    
+
     with mzml_data_struct['writer'].run(id=1, instrument_configuration='IC1', start_time=mzml_data_struct['data_dict']['acq_date_time']):
         with mzml_data_struct['writer'].spectrum_list(count=total_spectra_count):
             # Process Frames
@@ -974,18 +983,18 @@ def write_mzml(args):
             mzml_data_struct['scan_index'] = 1
 
             if mzml_data_struct['data_dict']['PASEFMSMS_type8'] == 1:
-                    
+
                 mzml_data_struct['precursor_frames'] = mzml_data_struct['td'].conn.execute("SELECT * From Frames where MsMsType=0").fetchall()
                 # Check upper frame range
                 if mzml_data_struct['end_frame'] == -1 or mzml_data_struct['end_frame'] > mzml_data_struct['data_dict']['frame_count']:
                     mzml_data_struct['end_frame'] = mzml_data_struct['data_dict']['frame_count']
-                    
+
                 for precursor_frame in mzml_data_struct['precursor_frames']:
                     # Get Precursor Frame ID
                     mzml_data_struct['current_precursor'] = {}
                     mzml_data_struct['current_precursor']['id'] = precursor_frame[0]
                     mzml_data_struct['current_precursor']['start_time'] = precursor_frame[1]/60
-                
+
                     if mzml_data_struct['current_precursor']['id'] < mzml_data_struct['start_frame'] or mzml_data_struct['current_precursor']['id'] > mzml_data_struct['end_frame']:
                         continue
 
@@ -993,59 +1002,59 @@ def write_mzml(args):
 
                     #logging.debug(mzml_data_struct['scan_index'])
                     scan_progress(mzml_data_struct)
-                    
+
                     for precursor_data in get_precursor_list(mzml_data_struct):
                         mzml_data_struct['current_precursor']['data'] = precursor_data
                         write_pasef_msms_spectrum(mzml_data_struct)
-            
+
                         scan_progress(mzml_data_struct)
-            
+
             elif mzml_data_struct['data_dict']['PASEFMSMS_type9'] == 1:
-                
+
                 mzml_data_struct['precursor_frames'] = mzml_data_struct['td'].conn.execute("SELECT * From Frames where MsMsType=0").fetchall()
                 mzml_data_struct['dia_frames'] = mzml_data_struct['td'].conn.execute("SELECT * From Frames where MsMsType=9").fetchall()
                 mzml_frames = mzml_data_struct['td'].conn.execute("SELECT * From Frames").fetchall()
                 # Check upper frame range
                 if mzml_data_struct['end_frame'] == -1 or mzml_data_struct['end_frame'] > mzml_data_struct['data_dict']['frame_count']:
                     mzml_data_struct['end_frame'] = mzml_data_struct['data_dict']['frame_count']
-                
+
                 for frame in mzml_frames:
-                #for precursor_frame in mzml_data_struct['precursor_frames']:
+                    #for precursor_frame in mzml_data_struct['precursor_frames']:
                     # Get Precursor Frame ID
-                    
+
                     if frame[4] == 0:
-                        
+
                         # if mzml_data_struct['current_precursor']['id'] < mzml_data_struct['start_frame'] or mzml_data_struct['current_precursor']['id'] > mzml_data_struct['end_frame']:
                         #     continue
-                        
+
                         mzml_data_struct['current_precursor'] = {}
                         mzml_data_struct['current_precursor']['id'] = frame[0]
                         mzml_data_struct['current_precursor']['start_time'] = frame[1]/60
-                
+
                         write_precursor_frame(mzml_data_struct)
 
                         #logging.debug(mzml_data_struct['scan_index'])
                         scan_progress(mzml_data_struct)
-                    
+
                     elif frame[4] == 9:
                         window_group = mzml_data_struct['td'].conn.execute("SELECT WindowGroup From DiaFrameMsMsInfo where Frame={}".format(frame[0])).fetchone()[0]
                         logging.debug( window_group )
                         windows = mzml_data_struct['td'].conn.execute("SELECT * From DiaFrameMsMsWindows where WindowGroup={}".format(window_group)).fetchall()
                         logging.debug( windows )
-                        
+
                         mzml_data_struct['current_dia_frame'] = {}
                         mzml_data_struct['current_dia_frame']['frame'] = frame
                         mzml_data_struct['current_dia_frame']['id'] = frame[0]
                         mzml_data_struct['current_dia_frame']['start_time'] = frame[1]/60
                         mzml_data_struct['current_dia_frame']['window_group'] = window_group
                         mzml_data_struct['current_dia_frame']['windows'] = windows
-                        
+
                         for window in windows:
                             mzml_data_struct['current_dia_frame']['current_window'] = window
- 
+
                             write_pasef_dia_spectrum(mzml_data_struct)
                             scan_progress(mzml_data_struct)
-            
+
                 #            logging.debug(window)
                 #             #print(frame[0], window[1], window[2])
                 #             # print(frame[0], list(range(window[1], window[2])))
@@ -1055,30 +1064,30 @@ def write_mzml(args):
                 #             # m_array = np.asarray(
                 #             #     mzml_data_struct['td'].indexToMz(frame[0], list(range(window[1], window[2])))
                 #             # )
-    
+
                 #             # result2 = np.asarray(result)
                 #             # print(  result2[np.argsort(result2)[-5:]])
                 #             # print( m_array )
-                            
+
                 #             result = mzml_data_struct['td'].extractCentroidedSpectrumForFrame( frame[0], window[1], window[2])
                 #             #print(result)
                 #             ms2_mz_array = np.asarray(result[0])
                 #             ms2_i_array = np.asarray(result[1])
-                            
+
                 #             msn_spectrum_id = "index={}".format(mzml_data_struct['scan_index'])
 
                 #             # parent_frame_string = "mz={}_width={} ".format(window[3],window[4])
-                                    
+
                 #             # precursor_info["spectrum_reference"] = mzml_data_struct['current_precursor']['spectrum_id']
 
                 #             # # TODO find the correct metadata and apply it here properly
                 #             # precursor_info["activation"] = [
-                #             #         "CID", 
+                #             #         "CID",
                 #             #         {"collision energy": pasef_frame["CollisionEnergy"]}
                 #             #         ]
 
                 #             # precursor_info["isolation_window_args"] = dict()
-                            
+
                 #             # if precursor['Charge'] != None:
                 #             #     precursor_mz = precursor['MonoisotopicMz']
                 #             #     precursor_info["mz"] = precursor_mz
@@ -1105,30 +1114,30 @@ def write_mzml(args):
                 #             #     precursor_info["charge"]  = 2
 
                 #             mzml_data_struct['writer'].write_spectrum(
-                #                 ms2_mz_array, 
-                #                 ms2_i_array, 
-                #                 id=msn_spectrum_id, 
+                #                 ms2_mz_array,
+                #                 ms2_i_array,
+                #                 id=msn_spectrum_id,
                 #                 centroided=True,
-                #                 scan_start_time=mzml_data_struct['current_precursor']['start_time'], 
+                #                 scan_start_time=mzml_data_struct['current_precursor']['start_time'],
                 #                 params=[
-                #                     {"ms level": 2}, 
+                #                     {"ms level": 2},
                 #                     {"total ion current": ms2_i_array.sum()}
                 #                 ]
                 #             )
 
                 #             mzml_data_struct['scan_index'] += 1
 
-                            
-                        
-                    #logging.debug(mzml_data_struct['scan_index'])
-                    #scan_progress(mzml_data_struct)
-                    
-                    # for precursor_data in get_precursor_list(mzml_data_struct):
-                    #     mzml_data_struct['current_precursor']['data'] = precursor_data
-                    #     write_pasef_msms_spectrum(mzml_data_struct)
-            
-                    #     scan_progress(mzml_data_struct)
-               
+
+
+                #logging.debug(mzml_data_struct['scan_index'])
+                #scan_progress(mzml_data_struct)
+
+                # for precursor_data in get_precursor_list(mzml_data_struct):
+                #     mzml_data_struct['current_precursor']['data'] = precursor_data
+                #     write_pasef_msms_spectrum(mzml_data_struct)
+
+                #     scan_progress(mzml_data_struct)
+
 
     logging.info("Writing final mzML")
     mzml_data_struct['writer'].end()
@@ -1236,8 +1245,8 @@ def main():
 
     parser.add_argument(
         "-d",
-        "--debug", 
-        default=False, 
+        "--debug",
+        default=False,
         action="store_true",
         help="print verbose debug messages")
 
@@ -1250,11 +1259,10 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)
-    
+
     write_mzml(args)
 
 
 if __name__ == "__main__":
 
     main()
-

--- a/tdf2mzml.py
+++ b/tdf2mzml.py
@@ -140,9 +140,9 @@ def centroid_precursor_frame(mzml_data_struct):
     """
     precursor_frame_id = mzml_data_struct['current_precursor']['id']
     num_scans = mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={0}".format(precursor_frame_id)).fetchone()[0]
-    print(mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={}".format(precursor_frame_id)).fetchone())
+    # print(mzml_data_struct['td'].conn.execute("SELECT NumScans FROM Frames WHERE Id={}".format(precursor_frame_id)).fetchone())
     data_list = mzml_data_struct['td'].extractCentroidedSpectrumForFrame (precursor_frame_id, 0, num_scans)
-    print(np.array(data_list))
+    # print(np.array(data_list))
     return np.array(data_list)
 
 


### PR DESCRIPTION
This branch has been tested by converting a timsTOF file to `mzML` and then running an EncyclopeDIA search on the resulting file, which appears to work without issue. In the current upstream `main` branch the produced mzML lacks any MS2 scans. In the current upstream `dia` branch the produced mzML incorrectly reported the precursor isolation window as the "scan window"; this branch correctly reports both the precursor isolation and scan windows.